### PR TITLE
docs(readme): Fix code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ $requestTimer->stop();
 $exporter = new StoredMetricsExporter(
     $registry,
     $storage,
-    new NullLogger(),
 );
 
 foreach ($exporter->export() as $metricOutput) {


### PR DESCRIPTION
`StoredMetricsExporter` doesn't have logger dependency